### PR TITLE
Start Cassandra nodes sequentially waiting for CQL

### DIFF
--- a/src/sso/cassandra.py
+++ b/src/sso/cassandra.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from sso.hdr import HdrLogProcessor
 from sso.ssh import SSH
 from sso.util import run_parallel, find_java, WorkerThread, log_important
+from sso.network_wait import wait_for_cql_start
 
 class Cassandra:
 
@@ -76,7 +77,9 @@ class Cassandra:
 
     def start(self):
         log_important("Start Cassandra: started")
-        run_parallel(self.__start, [(ip,) for ip in self.cluster_public_ips])
+        for ip in self.cluster_public_ips:
+            self.__start(ip)
+            wait_for_cql_start(ip)
         log_important("Start Cassandra: done")
         
     def __stop(self, ip):

--- a/src/sso/network_wait.py
+++ b/src/sso/network_wait.py
@@ -1,0 +1,34 @@
+from time import sleep
+from datetime import datetime, timedelta
+import socket
+
+def wait_for_port_start(node_ip, port, port_name, wait_reason='', timeout=900, connect_timeout=10, max_tries_per_second=2):
+    print(f'    [{node_ip}] Waiting for {port_name} port to start{wait_reason}. This could take a while.')
+
+    backoff_interval = 1.0 / max_tries_per_second
+    timeout_point = datetime.now() + timedelta(seconds=timeout)
+
+    feedback_interval = 20
+    print_feedback_point = datetime.now() + timedelta(seconds=feedback_interval)
+
+    while datetime.now() < timeout_point:
+        # Make a probe connection.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock: 
+            sock.settimeout(connect_timeout)
+            try:
+                sock.connect((node_ip, port))
+            except:
+                # There was a problem connecting to the port.
+                sleep(backoff_interval)
+                if datetime.now() > print_feedback_point:
+                    print_feedback_point = datetime.now() + timedelta(seconds=feedback_interval)
+                    print(f'    [{node_ip}] Still waiting for {port_name} port to start...')
+            else:
+                print(f'    [{node_ip}] Successfully connected to {port_name} port.')
+                return
+
+    raise Exception(f'Waiting for {port_name} to start timed out after {timeout} seconds for node: {node_ip}.')
+
+def wait_for_cql_start(node_ip, timeout=900, connect_timeout=10, max_tries_per_second=2):
+    wait_for_port_start(node_ip, 9042, 'CQL', ' (meaning node bootstrap finished)', timeout=timeout, 
+        connect_timeout=connect_timeout, max_tries_per_second=max_tries_per_second)


### PR DESCRIPTION
Previously, Cassandra nodes were started concurrently (all at once). However, this is not a correct approach - the nodes should be started one by one, waiting for each node to fully bootstrap.

This commit changes the behavior to match those best practices. To determine whether a node has fully bootstrapped, checking the CQL port for availability is performed (in both Cassandra and Scylla, CQL port is only started after node bootstrap is fully finished).

Partially addresses #10 (Scylla logic is still wrong - I will address it in next PR dependent on this PR).